### PR TITLE
Add DragonCrestTrinketDTO and replace dragonstone storage wirth List (#103)

### DIFF
--- a/src/main/java/com/langleon/dsobuildsim/character/Character.java
+++ b/src/main/java/com/langleon/dsobuildsim/character/Character.java
@@ -41,7 +41,7 @@ public class Character {
 
     private List<RuneTrinket> runeTrinkets;
     private List<JewelTrinket> jewelTrinkets;
-    private DragonCrestTrinket dragonCrestTrinket;
+    private final DragonCrestTrinket dragonCrestTrinket;
 
     private Map<ItemSlot, Item> equippedItems;
     private Map<SetType, SetInstance> equippedSets;
@@ -59,7 +59,8 @@ public class Character {
     private WisdomSkillTree wisdomSkillTree;
 
     //default constructor
-    public Character(CharacterClass characterClass, SetFactory setFactory, WisdomSkillTreeFactory wisdomSkillTreeFactory)
+    public Character(CharacterClass characterClass, SetFactory setFactory, WisdomSkillTreeFactory wisdomSkillTreeFactory,
+                     DragonCrestTrinket dragonCrest)
     {
         this.setFactory = setFactory;
 
@@ -81,7 +82,7 @@ public class Character {
         for (int i = 0; i < 3; i++) {
             jewelTrinkets.add(new JewelTrinket());
         }
-        this.dragonCrestTrinket = new DragonCrestTrinket();
+        this.dragonCrestTrinket = dragonCrest;
 
         this.equippedItems = new EnumMap<>(ItemSlot.class);
         this.equippedSets = new EnumMap<>(SetType.class);
@@ -191,11 +192,6 @@ public class Character {
 
     public DragonCrestTrinket getDragonCrestTrinket() {
         return dragonCrestTrinket;
-    }
-
-    public void updateDragonCrestTrinket(DragonStone[] dragonStones)
-    {
-        this.dragonCrestTrinket.updateDragonStones(dragonStones);
     }
 
     public void equipItem(ItemSlot slot, Item item)

--- a/src/main/java/com/langleon/dsobuildsim/dragonstones/DragonCrestTrinket.java
+++ b/src/main/java/com/langleon/dsobuildsim/dragonstones/DragonCrestTrinket.java
@@ -3,56 +3,34 @@ package com.langleon.dsobuildsim.dragonstones;
 import com.langleon.dsobuildsim.common.StatType;
 
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class DragonCrestTrinket {
 
-    private DragonStone[] dragonStones;
+    private final List<DragonStone> dragonStones;
 
-    public DragonCrestTrinket() {
-        this.dragonStones = new DragonStone[10];
+    public DragonCrestTrinket(List<DragonStone> dragonStones) {
+        if (dragonStones.size() > 10) throw new IllegalArgumentException("Dragon Crest can only hold 10 Dragon Stones.");
+        this.dragonStones = List.copyOf(dragonStones);
     }
 
-    public DragonStone[] getDragonStones() {
+    public List<DragonStone> getDragonStones() {
         return dragonStones;
-    }
-
-    public DragonStone getDragonStone(int slot) {
-        return dragonStones[slot];
-    }
-
-    public void addDragonStone(DragonStone dragonStone, int slot)
-    {
-        if (dragonStone==null) throw new IllegalArgumentException("Dragon Stone is null!");
-        if (slot<0 || slot>10) throw new IllegalArgumentException("Index out of range!");
-        dragonStones[slot] = dragonStone;
-    }
-
-    public void removeDragonStone(int slot)
-    {
-        if (slot<0 || slot>10) throw new IllegalArgumentException("Index out of range!");
-        dragonStones[slot] = null;
-    }
-
-    public void updateDragonStones(DragonStone[] dragonStones)
-    {
-        if (dragonStones.length!=10) throw new IllegalArgumentException("Invalid array length!");
-        this.dragonStones = dragonStones;
     }
 
     public Map<StatType, Double> getTotalRelativeStats()
     {
-        Map<StatType, Double> stats = new EnumMap<>(StatType.class);
-        for(int i=0; i<10; i++)
-        {
-            if (dragonStones[i]!=null)
-            {
-                for(Map.Entry<StatType, Double> entry : dragonStones[i].stats().entrySet())
-                {
-                    stats.merge(entry.getKey(), entry.getValue(), Double::sum);
-                }
-            }
-        }
-        return stats;
+        return dragonStones.stream()
+                .filter(Objects::nonNull)
+                .flatMap(ds -> ds.stats().entrySet().stream())
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        Double::sum,
+                        () -> new EnumMap<>(StatType.class)
+                ));
     }
 }

--- a/src/main/java/com/langleon/dsobuildsim/dragonstones/DragonStoneFactory.java
+++ b/src/main/java/com/langleon/dsobuildsim/dragonstones/DragonStoneFactory.java
@@ -1,5 +1,6 @@
 package com.langleon.dsobuildsim.dragonstones;
 
+import com.langleon.dsobuildsim.dragonstones.dto.DragonCrestTrinketDTO;
 import com.langleon.dsobuildsim.dragonstones.dto.DragonStoneInstanceDTO;
 
 import java.util.List;
@@ -29,5 +30,10 @@ public class DragonStoneFactory {
         return dtos.stream()
                 .map(this::fromDTO)
                 .toList();
+    }
+
+    public DragonCrestTrinket fromDTO(DragonCrestTrinketDTO dragonCrest)
+    {
+        return new DragonCrestTrinket(fromDTOList(dragonCrest.dragonStones()));
     }
 }

--- a/src/main/java/com/langleon/dsobuildsim/dragonstones/dto/DragonCrestTrinketDTO.java
+++ b/src/main/java/com/langleon/dsobuildsim/dragonstones/dto/DragonCrestTrinketDTO.java
@@ -1,0 +1,8 @@
+package com.langleon.dsobuildsim.dragonstones.dto;
+
+import java.util.List;
+
+public record DragonCrestTrinketDTO(
+        List<DragonStoneInstanceDTO> dragonStones
+) {
+}

--- a/src/test/java/com/langleon/dsobuildsim/character/CharacterTest.java
+++ b/src/test/java/com/langleon/dsobuildsim/character/CharacterTest.java
@@ -1,5 +1,6 @@
 package com.langleon.dsobuildsim.character;
 
+import com.langleon.dsobuildsim.dragonstones.*;
 import com.langleon.dsobuildsim.wisdomskilltree.WisdomSkillTreeConfig;
 import com.langleon.dsobuildsim.wisdomskilltree.WisdomSkillTreeFactory;
 import com.langleon.dsobuildsim.wisdomskilltree.wisdomgroup.WisdomGroupConfig;
@@ -7,16 +8,12 @@ import com.langleon.dsobuildsim.wisdomskilltree.wisdomgroup.WisdomGroupType;
 import com.langleon.dsobuildsim.wisdomskilltree.wisdomskill.WisdomSkillConfig;
 import com.langleon.dsobuildsim.wisdomskilltree.wisdomskill.WisdomSkillType;
 import tools.jackson.databind.ObjectMapper;
-import com.langleon.dsobuildsim.dragonstones.DragonStone;
-import com.langleon.dsobuildsim.dragonstones.DragonStoneConfig;
-import com.langleon.dsobuildsim.dragonstones.DragonStoneFactory;
 import com.langleon.dsobuildsim.enchantments.Enchantment;
 import com.langleon.dsobuildsim.enchantments.EnchantmentConfig;
 import com.langleon.dsobuildsim.enchantments.EnchantmentDefinition;
 import com.langleon.dsobuildsim.gems.AbstractGem;
 import com.langleon.dsobuildsim.items.core.enums.ItemSlot;
 import com.langleon.dsobuildsim.common.StatType;
-import com.langleon.dsobuildsim.dragonstones.DragonStoneType;
 import com.langleon.dsobuildsim.essences.EssenceType;
 import com.langleon.dsobuildsim.gems.enums.GemType;
 import com.langleon.dsobuildsim.items.mythicitems.MythicItemType;
@@ -176,7 +173,10 @@ public class CharacterTest {
 
     private Character createCharacter()
     {
-        Character character = new Character(CharacterClass.SPELLWEAVER, setFactory, wisdomSkillTreeFactory);
+        DragonCrestTrinket dragonCrest = new DragonCrestTrinket(List.of(dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 5), dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 5), dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3), dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3), dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3)));
+
+        Character character = new Character(CharacterClass.SPELLWEAVER, setFactory, wisdomSkillTreeFactory,
+                dragonCrest);
 
         character.setExperienceBonusPathLevel(5);
         character.setElementalMasteryType(MasteryType.ICE);
@@ -192,8 +192,6 @@ public class CharacterTest {
         character.updateJewelTrinket(0, new Jewel[]{jewelFactory.createJewel(JewelType.ETERNAL_SCORN, CharacterClass.SPELLWEAVER, 7), jewelFactory.createJewel(JewelType.GLORY, CharacterClass.SPELLWEAVER, 7), jewelFactory.createJewel(JewelType.RAGE, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.AMPLIFIED_HEALING, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FROZEN_HEART, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.GEM_FORTUNE, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.ETERNAL_WRATH, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.INGREDIENT_HUNTER, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.INGREDIENT_HUNTER, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.INGREDIENT_HUNTER, CharacterClass.SPELLWEAVER, 5),});
         character.updateJewelTrinket(1, new Jewel[]{jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.VIGOR, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.AMBIDEXTROUS_VIGOR, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.VITALITY, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.ENCOURAGEMENT, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.CONTRIBUTION, CharacterClass.SPELLWEAVER, 5),});
         character.updateJewelTrinket(2, new Jewel[]{jewelFactory.createJewel(JewelType.LASTING_HEALTH, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.CONVERSE, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FLOWER, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.STRENUOUSNESS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FORTITUDE, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.PROLONGATION, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.REVIVAL_BOON, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.EASTER_FEVER, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.SCORCHING_RAY, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.PENT_UP_POWER, CharacterClass.SPELLWEAVER, 5),});
-
-        character.updateDragonCrestTrinket(new DragonStone[]{dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 5), dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 5), dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3), dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3), dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3), null, null, null, null, null});
 
         EnchantmentDefinition enchantDefHP = enchantmentConfig.enchantments().get(StatType.HEALTH_POINTS);
         EnchantmentDefinition enchantDefDMG = enchantmentConfig.enchantments().get(StatType.DAMAGE);

--- a/src/test/java/com/langleon/dsobuildsim/character/EquipmentLimitTest.java
+++ b/src/test/java/com/langleon/dsobuildsim/character/EquipmentLimitTest.java
@@ -113,7 +113,7 @@ public class EquipmentLimitTest {
     // Gems
     @Test
     void updateItemGems_succeedsIfWithinGemLimit() throws NoSuchFieldException, IllegalAccessException {
-        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory);
+        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, null);
         character.equipItem(ItemSlot.AMULET, itemFactory.createItem(SetItemType.WINTER_AMULET, CharacterClass.SPELLWEAVER, Map.of(StatType.DAMAGE, 0.0, StatType.MOVEMENT_SPEED, 0.0, StatType.HEALTH_POINTS, 0.0), 145));
         character.updateItemGems(ItemSlot.AMULET, new Gem[]{gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17)});
         character.equipItem(ItemSlot.CLOAK, itemFactory.createItem(SetItemType.DRAGAN_CLOAK, CharacterClass.SPELLWEAVER, Map.of(StatType.DAMAGE, 0.0, StatType.ATTACK_SPEED, 0.0, StatType.HEALTH_POINTS, 0.0), 145));
@@ -134,7 +134,7 @@ public class EquipmentLimitTest {
     @Test
     void equipItem_updateItemGems_throwsIfGemLimitExceeded()
     {
-        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory);
+        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, null);
         Item amulet = itemFactory.createItem(SetItemType.WINTER_AMULET, CharacterClass.SPELLWEAVER, Map.of(StatType.DAMAGE, 0.0, StatType.MOVEMENT_SPEED, 0.0, StatType.HEALTH_POINTS, 0.0), 145);
         amulet.setGems(new Gem[]{gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17)});
         character.equipItem(ItemSlot.AMULET, amulet);
@@ -159,7 +159,7 @@ public class EquipmentLimitTest {
     @Test
     void updateItemGems_throwsIfGemLimitExceeded()
     {
-        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory);
+        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, null);
         character.equipItem(ItemSlot.AMULET, itemFactory.createItem(SetItemType.WINTER_AMULET, CharacterClass.SPELLWEAVER, Map.of(StatType.DAMAGE, 0.0, StatType.MOVEMENT_SPEED, 0.0, StatType.HEALTH_POINTS, 0.0), 145));
         character.updateItemGems(ItemSlot.AMULET, new Gem[]{gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17)});
         character.equipItem(ItemSlot.CLOAK, itemFactory.createItem(SetItemType.DRAGAN_CLOAK, CharacterClass.SPELLWEAVER, Map.of(StatType.DAMAGE, 0.0, StatType.ATTACK_SPEED, 0.0, StatType.HEALTH_POINTS, 0.0), 145));
@@ -178,7 +178,7 @@ public class EquipmentLimitTest {
     // Runes
     @Test
     void updateRuneTrinket_succeedsIfWithinRuneLimit() throws IllegalAccessException, NoSuchFieldException {
-        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory);
+        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, null);
         character.updateRuneTrinket(0, new Rune[]{runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5)});
         character.updateRuneTrinket(1, new Rune[]{runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5)});
         character.updateRuneTrinket(2, new Rune[]{runeFactory.createRune(RuneType.MATERI_BLESSING, 5), runeFactory.createRune(RuneType.MATERI_BLESSING, 5), runeFactory.createRune(RuneType.MATERI_BLESSING, 5), runeFactory.createRune(RuneType.MATERI_BLESSING, 5), runeFactory.createRune(RuneType.MATERI_BLESSING, 5), runeFactory.createRune(RuneType.WISDOM_SEEKER, 5), runeFactory.createRune(RuneType.WISDOM_SEEKER, 5), runeFactory.createRune(RuneType.WISDOM_SEEKER, 5), runeFactory.createRune(RuneType.WISDOM_SEEKER, 5), runeFactory.createRune(RuneType.WISDOM_SEEKER, 5)});
@@ -198,7 +198,7 @@ public class EquipmentLimitTest {
     @Test
     void updateRuneTrinket_throwsIfRuneLimitExceeded()
     {
-        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory);
+        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, null);
         Assertions.assertThrows(IllegalArgumentException.class, () -> character.updateRuneTrinket(0, new Rune[]{runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5)}));
         Assertions.assertThrows(IllegalArgumentException.class, () -> character.updateRuneTrinket(0, new Rune[]{runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.FIRE_RESILIENCE, 5), runeFactory.createRune(RuneType.FIRE_RESILIENCE, 5), runeFactory.createRune(RuneType.FIRE_RESILIENCE, 5), runeFactory.createRune(RuneType.FIRE_RESILIENCE, 5), runeFactory.createRune(RuneType.ICE_RESILIENCE, 5), runeFactory.createRune(RuneType.ICE_RESILIENCE, 5)}));
         Assertions.assertThrows(IllegalArgumentException.class, () -> character.updateRuneTrinket(0, new Rune[]{runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.RISING_VIGOR, 5), runeFactory.createRune(RuneType.RISING_POWER, 5)}));
@@ -207,7 +207,7 @@ public class EquipmentLimitTest {
     // Jewels
     @Test
     void updateJewelTrinket_succeedsIfWithinJewelLimit() throws IllegalAccessException, NoSuchFieldException {
-        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory);
+        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, null);
         character.updateJewelTrinket(0, new Jewel[]{jewelFactory.createJewel(JewelType.FOCUS,  CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.RAGE, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.SCORCHING_RAY, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.ETERNAL_SCORN, CharacterClass.SPELLWEAVER, 7), jewelFactory.createJewel(JewelType.ETERNAL_WRATH, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.INGREDIENT_HUNTER, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.AMBIDEXTROUS_VIGOR, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.VITALITY, CharacterClass.SPELLWEAVER, 5)});
 
         Field jewelLimitsField = Character.class.getDeclaredField("jewelLimits");
@@ -227,7 +227,7 @@ public class EquipmentLimitTest {
     @Test
     void updateJewelTrinket_throwsIfJewelLimitExceeded()
     {
-        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory);
+        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, null);
         character.updateJewelTrinket(0, new Jewel[]{jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.RAGE, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.SCORCHING_RAY, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.ETERNAL_SCORN, CharacterClass.SPELLWEAVER, 7), jewelFactory.createJewel(JewelType.ETERNAL_WRATH, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.GEM_FORTUNE, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.AMBIDEXTROUS_VIGOR, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.VITALITY, CharacterClass.SPELLWEAVER, 5)});
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> character.updateJewelTrinket(1, new Jewel[]{jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.BLACK_KNIGHT_ORDER, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.INGREDIENT_HUNTER, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.INGREDIENT_HUNTER, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.INGREDIENT_HUNTER, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.VIGOR, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.GLORY, CharacterClass.SPELLWEAVER, 5)}));

--- a/src/test/java/com/langleon/dsobuildsim/dragonstones/DragonCrestTrinketTest.java
+++ b/src/test/java/com/langleon/dsobuildsim/dragonstones/DragonCrestTrinketTest.java
@@ -1,5 +1,6 @@
 package com.langleon.dsobuildsim.dragonstones;
 
+import com.langleon.dsobuildsim.dragonstones.dto.DragonCrestTrinketDTO;
 import tools.jackson.databind.ObjectMapper;
 import com.langleon.dsobuildsim.common.StatType;
 import org.junit.jupiter.api.Assertions;
@@ -8,7 +9,10 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class DragonCrestTrinketTest {
 
@@ -17,7 +21,7 @@ public class DragonCrestTrinketTest {
     @BeforeEach
     void setup() throws IOException
     {
-        try (var reader = new InputStreamReader(getClass().getResourceAsStream("/gamedata/dragonstones.json")))
+        try (var reader = new InputStreamReader(Objects.requireNonNull(getClass().getResourceAsStream("/gamedata/dragonstones.json"))))
         {
             ObjectMapper objectMapper = new ObjectMapper();
             DragonStoneConfig dragonStoneConfig = objectMapper.readValue(reader, DragonStoneConfig.class);
@@ -28,65 +32,63 @@ public class DragonCrestTrinketTest {
     @Test
     void testDragonCrestCreation()
     {
-        DragonCrestTrinket dragonCrest = new DragonCrestTrinket();
-        Assertions.assertNotNull(dragonCrest);
-    }
+        List<DragonStone> dragonStones = new ArrayList<>();
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.GREEDSTONE, 4));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.RESTLESS_STONE, 5));
+        DragonCrestTrinket dragonCrest = new DragonCrestTrinket(dragonStones);
 
-    @Test
-    void testAddDragonStones()
-    {
-        DragonCrestTrinket dragonCrest = new DragonCrestTrinket();
-        dragonCrest.addDragonStone(dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3),2);
-        dragonCrest.addDragonStone(dragonStoneFactory.createDragonStone(DragonStoneType.GREEDSTONE, 4),9);
-        dragonCrest.addDragonStone(dragonStoneFactory.createDragonStone(DragonStoneType.RESTLESS_STONE, 5),3);
-        DragonStone[] dragonStones = dragonCrest.getDragonStones();
-        Assertions.assertNotNull(dragonStones);
-        Assertions.assertEquals(dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3), dragonStones[2]);
-        Assertions.assertEquals(dragonStoneFactory.createDragonStone(DragonStoneType.GREEDSTONE, 4), dragonStones[9]);
-        Assertions.assertEquals(dragonStoneFactory.createDragonStone(DragonStoneType.RESTLESS_STONE, 5), dragonStones[3]);
-        Assertions.assertNull(dragonStones[1]);
-        Assertions.assertEquals(dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3), dragonCrest.getDragonStone(2));
-        Assertions.assertEquals(dragonStoneFactory.createDragonStone(DragonStoneType.GREEDSTONE, 4), dragonCrest.getDragonStone(9));
-        Assertions.assertEquals(dragonStoneFactory.createDragonStone(DragonStoneType.RESTLESS_STONE, 5), dragonCrest.getDragonStone(3));
-        Assertions.assertNull(dragonCrest.getDragonStone(1));
-    }
-
-    @Test
-    void testRemoveDragonStones()
-    {
-        DragonCrestTrinket dragonCrest = new DragonCrestTrinket();
-        dragonCrest.addDragonStone(dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3),2);
-        dragonCrest.addDragonStone(dragonStoneFactory.createDragonStone(DragonStoneType.GREEDSTONE, 4),9);
-        dragonCrest.addDragonStone(dragonStoneFactory.createDragonStone(DragonStoneType.RESTLESS_STONE, 5),3);
-        Assertions.assertEquals(dragonStoneFactory.createDragonStone(DragonStoneType.RESTLESS_STONE, 5), dragonCrest.getDragonStone(3));
-        dragonCrest.removeDragonStone(3);
-        Assertions.assertNull(dragonCrest.getDragonStone(3));
+        List<DragonStone> dragonStonesActual = dragonCrest.getDragonStones();
+        Assertions.assertNotNull(dragonStonesActual);
+        Assertions.assertEquals(3, dragonCrest.getDragonStones().size());
+        Assertions.assertEquals(dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3), dragonStonesActual.get(0));
+        Assertions.assertEquals(dragonStoneFactory.createDragonStone(DragonStoneType.GREEDSTONE, 4), dragonStonesActual.get(1));
+        Assertions.assertEquals(dragonStoneFactory.createDragonStone(DragonStoneType.RESTLESS_STONE, 5), dragonStonesActual.get(2));
     }
 
     @Test
     void testGetTotalStats()
     {
-        DragonCrestTrinket dragonCrest = new DragonCrestTrinket();
-        dragonCrest.addDragonStone(dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3),0);
-        dragonCrest.addDragonStone(dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3),1);
-        dragonCrest.addDragonStone(dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 4),1);
-        dragonCrest.addDragonStone(dragonStoneFactory.createDragonStone(DragonStoneType.GREEDSTONE, 5),3);
-        dragonCrest.addDragonStone(dragonStoneFactory.createDragonStone(DragonStoneType.GREEDSTONE, 5),4);
-        dragonCrest.addDragonStone(dragonStoneFactory.createDragonStone(DragonStoneType.GREEDSTONE, 5),5);
-        dragonCrest.addDragonStone(dragonStoneFactory.createDragonStone(DragonStoneType.FURYSTONE, 5),6);
-        dragonCrest.addDragonStone(dragonStoneFactory.createDragonStone(DragonStoneType.FURYSTONE, 5),7);
-        dragonCrest.addDragonStone(dragonStoneFactory.createDragonStone(DragonStoneType.RESTLESS_STONE, 5),8);
-        dragonCrest.addDragonStone(dragonStoneFactory.createDragonStone(DragonStoneType.RESTLESS_STONE, 5),9);
+        List<DragonStone> dragonStones = new ArrayList<>();
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 4));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.GREEDSTONE, 5));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.GREEDSTONE, 5));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.GREEDSTONE, 5));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.FURYSTONE, 5));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.FURYSTONE, 5));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.RESTLESS_STONE, 5));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.RESTLESS_STONE, 5));
+        DragonCrestTrinket dragonCrest = new DragonCrestTrinket(dragonStones);
         Map<StatType, Double> stats = dragonCrest.getTotalRelativeStats();
         Assertions.assertEquals(4, stats.size());
         Assertions.assertTrue(stats.containsKey(StatType.HEALTH_POINTS));
         Assertions.assertTrue(stats.containsKey(StatType.ANDERMANT_DROP_BONUS));
         Assertions.assertTrue(stats.containsKey(StatType.DAMAGE));
         Assertions.assertTrue(stats.containsKey(StatType.ATTACK_SPEED));
-        Assertions.assertEquals(0.075, stats.get(StatType.HEALTH_POINTS), 1e-9);
+        Assertions.assertEquals(0.1, stats.get(StatType.HEALTH_POINTS), 1e-9);
         Assertions.assertEquals(0.06, stats.get(StatType.ANDERMANT_DROP_BONUS), 1e-9);
         Assertions.assertEquals(-0.03, stats.get(StatType.DAMAGE), 1e-9);
         Assertions.assertEquals(0.09, stats.get(StatType.ATTACK_SPEED), 1e-9);
+    }
+
+    @Test
+    void shouldThrowOnElevenOrMoreStones()
+    {
+        List<DragonStone> dragonStones = new ArrayList<>();
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 4));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.GREEDSTONE, 5));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.GREEDSTONE, 5));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.GREEDSTONE, 5));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.FURYSTONE, 5));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.FURYSTONE, 5));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.RESTLESS_STONE, 5));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.RESTLESS_STONE, 5));
+        dragonStones.add(dragonStoneFactory.createDragonStone(DragonStoneType.RESTLESS_STONE, 5));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new DragonCrestTrinket(dragonStones));
     }
 
 }

--- a/src/test/java/com/langleon/dsobuildsim/dragonstones/DragonStoneFactoryTest.java
+++ b/src/test/java/com/langleon/dsobuildsim/dragonstones/DragonStoneFactoryTest.java
@@ -1,5 +1,6 @@
 package com.langleon.dsobuildsim.dragonstones;
 
+import com.langleon.dsobuildsim.dragonstones.dto.DragonCrestTrinketDTO;
 import com.langleon.dsobuildsim.dragonstones.dto.DragonStoneInstanceDTO;
 import tools.jackson.databind.ObjectMapper;
 import com.langleon.dsobuildsim.common.StatType;
@@ -81,8 +82,8 @@ public class DragonStoneFactoryTest {
     {
         DragonStoneInstanceDTO dragonStoneDefinitionDTO1 = new DragonStoneInstanceDTO(DragonStoneType.POWERSTONE,4);
         DragonStoneInstanceDTO dragonStoneDefinitionDTO2 = new DragonStoneInstanceDTO(DragonStoneType.GREEDSTONE, 4);
-        List<DragonStoneInstanceDTO> dragonStoneDefinitionDTOS = List.of(dragonStoneDefinitionDTO1, dragonStoneDefinitionDTO2);
-        List<DragonStone> dragonStones = dragonStoneFactory.fromDTOList(dragonStoneDefinitionDTOS);
+        List<DragonStoneInstanceDTO> dragonStoneInstanceDTOs = List.of(dragonStoneDefinitionDTO1, dragonStoneDefinitionDTO2);
+        List<DragonStone> dragonStones = dragonStoneFactory.fromDTOList(dragonStoneInstanceDTOs);
 
         Assertions.assertEquals(DragonStoneType.POWERSTONE, dragonStones.getFirst().dragonStoneType());
         Assertions.assertEquals(4, dragonStones.getFirst().tier());
@@ -92,5 +93,24 @@ public class DragonStoneFactoryTest {
         Assertions.assertEquals(4, dragonStones.get(1).tier());
         Assertions.assertEquals(Map.of(StatType.ANDERMANT_DROP_BONUS, 0.01), dragonStones.get(1).stats());
         Assertions.assertEquals("+ 1% drop stack size of Andermant", dragonStones.get(1).description());
+    }
+
+    @Test
+    void shouldResolveDragonStonesFromDragonCrestDTO()
+    {
+        DragonStoneInstanceDTO dragonStoneDefinitionDTO1 = new DragonStoneInstanceDTO(DragonStoneType.POWERSTONE,4);
+        DragonStoneInstanceDTO dragonStoneDefinitionDTO2 = new DragonStoneInstanceDTO(DragonStoneType.GREEDSTONE, 4);
+        List<DragonStoneInstanceDTO> dragonStoneInstanceDTOs = List.of(dragonStoneDefinitionDTO1, dragonStoneDefinitionDTO2);
+        DragonCrestTrinketDTO dragonCrestTrinketDTO = new DragonCrestTrinketDTO(dragonStoneInstanceDTOs);
+        DragonCrestTrinket dragonCrest = dragonStoneFactory.fromDTO(dragonCrestTrinketDTO);
+
+        Assertions.assertEquals(DragonStoneType.POWERSTONE, dragonCrest.getDragonStones().getFirst().dragonStoneType());
+        Assertions.assertEquals(4, dragonCrest.getDragonStones().getFirst().tier());
+        Assertions.assertEquals(Map.of(StatType.HEALTH_POINTS, 0.05), dragonCrest.getDragonStones().getFirst().stats());
+        Assertions.assertEquals("+ 5.00% Health Points", dragonCrest.getDragonStones().getFirst().description());
+        Assertions.assertEquals(DragonStoneType.GREEDSTONE, dragonCrest.getDragonStones().get(1).dragonStoneType());
+        Assertions.assertEquals(4, dragonCrest.getDragonStones().get(1).tier());
+        Assertions.assertEquals(Map.of(StatType.ANDERMANT_DROP_BONUS, 0.01), dragonCrest.getDragonStones().get(1).stats());
+        Assertions.assertEquals("+ 1% drop stack size of Andermant", dragonCrest.getDragonStones().get(1).description());
     }
 }

--- a/src/test/java/com/langleon/dsobuildsim/jewels/JewelTrinketTest.java
+++ b/src/test/java/com/langleon/dsobuildsim/jewels/JewelTrinketTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Map;
+import java.util.Objects;
 
 public class JewelTrinketTest {
 
@@ -19,19 +20,12 @@ public class JewelTrinketTest {
     @BeforeEach
     void setup() throws IOException
     {
-        try (var reader = new InputStreamReader(getClass().getResourceAsStream("/gamedata/jewels.json")))
+        try (var reader = new InputStreamReader(Objects.requireNonNull(getClass().getResourceAsStream("/gamedata/jewels.json"))))
         {
             ObjectMapper objectMapper = new ObjectMapper();
             JewelConfig jewelConfig = objectMapper.readValue(reader, JewelConfig.class);
             jewelFactory = new JewelFactory(jewelConfig);
         }
-    }
-
-    @Test
-    void testDragonCrestCreation()
-    {
-        DragonCrestTrinket jewelTrinket = new DragonCrestTrinket();
-        Assertions.assertNotNull(jewelTrinket);
     }
 
     @Test


### PR DESCRIPTION
Introduce DragonStoneTrinketDTO to encapsulate dragonstone instances in a dedicated container.
Replaces raw list usage and aligns dragonstone structure with other slot-based systems.