### PR TITLE
Introduce RuneTrinketDTO and replace rune array storage with List

### DIFF
--- a/src/main/java/com/langleon/dsobuildsim/character/Character.java
+++ b/src/main/java/com/langleon/dsobuildsim/character/Character.java
@@ -4,7 +4,6 @@ import com.langleon.dsobuildsim.buffs.Physic;
 import com.langleon.dsobuildsim.buffs.Tonic;
 import com.langleon.dsobuildsim.common.StatType;
 import com.langleon.dsobuildsim.dragonstones.DragonCrestTrinket;
-import com.langleon.dsobuildsim.dragonstones.DragonStone;
 import com.langleon.dsobuildsim.gems.AbstractGem;
 import com.langleon.dsobuildsim.gems.enums.GemLimitGroup;
 import com.langleon.dsobuildsim.items.core.enums.ItemSlot;
@@ -19,7 +18,6 @@ import com.langleon.dsobuildsim.items.core.Item;
 import com.langleon.dsobuildsim.jewels.Jewel;
 import com.langleon.dsobuildsim.jewels.JewelTrinket;
 import com.langleon.dsobuildsim.pets.Pet;
-import com.langleon.dsobuildsim.runes.Rune;
 import com.langleon.dsobuildsim.runes.RuneTrinket;
 import com.langleon.dsobuildsim.wisdomskilltree.WisdomSkillTree;
 import com.langleon.dsobuildsim.wisdomskilltree.WisdomSkillTreeFactory;
@@ -39,14 +37,13 @@ public class Character {
     private boolean experienceBonusPath;
     private int experienceBonusPathLevel;
 
-    private List<RuneTrinket> runeTrinkets;
+    private final List<RuneTrinket> runeTrinkets;
     private List<JewelTrinket> jewelTrinkets;
     private final DragonCrestTrinket dragonCrestTrinket;
 
     private Map<ItemSlot, Item> equippedItems;
     private Map<SetType, SetInstance> equippedSets;
     private Map<GemLimitGroup, Integer> gemLimits;
-    private Map<RuneLimitGroup, Integer> runeLimits;
     private Map<JewelType, Integer> jewelLimits;
 
     private Pet pet;
@@ -60,7 +57,7 @@ public class Character {
 
     //default constructor
     public Character(CharacterClass characterClass, SetFactory setFactory, WisdomSkillTreeFactory wisdomSkillTreeFactory,
-                     DragonCrestTrinket dragonCrest)
+                     List<RuneTrinket> runeTrinkets, DragonCrestTrinket dragonCrest)
     {
         this.setFactory = setFactory;
 
@@ -71,13 +68,10 @@ public class Character {
         this.experienceBonusPath = false;
         this.experienceBonusPathLevel = 0;
         this.gemLimits = new EnumMap<>(GemLimitGroup.class);
-        this.runeLimits = new EnumMap<>(RuneLimitGroup.class);
         this.jewelLimits = new EnumMap<>(JewelType.class);
 
-        this.runeTrinkets = new ArrayList<>(7);
-        for (int i = 0; i < 7; i++) {
-            this.runeTrinkets.add(new RuneTrinket());
-        }
+        this.validateRunes(runeTrinkets);
+        this.runeTrinkets = runeTrinkets;
         this.jewelTrinkets = new ArrayList<>(3);
         for (int i = 0; i < 3; i++) {
             jewelTrinkets.add(new JewelTrinket());
@@ -134,34 +128,6 @@ public class Character {
         this.experienceBonusPathLevel = level;
     }
 
-    public List<RuneTrinket> getRuneTrinkets() {
-        return runeTrinkets;
-    }
-
-    public RuneTrinket getRuneTrinket(int index) {
-        return runeTrinkets.get(index);
-    }
-
-    public void updateRuneTrinket(int index, Rune[] runes)
-    {
-        Map<RuneLimitGroup, Integer> oldRunes = this.countByLimitGroup(this.runeTrinkets.get(index).getRunes(), Rune::getRuneLimitGroup, RuneLimitGroup.class);
-        Map<RuneLimitGroup, Integer> newRunes = this.countByLimitGroup(runes, Rune::getRuneLimitGroup, RuneLimitGroup.class);
-
-        for (Map.Entry<RuneLimitGroup, Integer> entry : newRunes.entrySet()) {
-            RuneLimitGroup group = entry.getKey();
-            int globalCount = this.runeLimits.getOrDefault(group, 0);
-            int oldCount = oldRunes.getOrDefault(group, 0);
-            int newCount = entry.getValue();
-
-            if (globalCount - oldCount + newCount > group.getLimit()) {
-                throw new IllegalArgumentException("Rune limit exceeded for " + group + ".");
-            }
-        }
-
-        this.updateGlobalLimits(oldRunes, newRunes, this.runeLimits);
-        this.runeTrinkets.get(index).updateRunes(runes);
-    }
-
     public List<JewelTrinket> getJewelTrinkets() {
         return jewelTrinkets;
     }
@@ -188,10 +154,6 @@ public class Character {
 
         this.updateGlobalLimits(oldJewels, newJewels, this.jewelLimits);
         this.jewelTrinkets.get(index).updateJewels(jewels);
-    }
-
-    public DragonCrestTrinket getDragonCrestTrinket() {
-        return dragonCrestTrinket;
     }
 
     public void equipItem(ItemSlot slot, Item item)
@@ -345,6 +307,20 @@ public class Character {
 
     public void setWisdomSkillTree(WisdomSkillTree wisdomSkillTree) {
         this.wisdomSkillTree = wisdomSkillTree;
+    }
+
+    private void validateRunes(List<RuneTrinket> runeTrinkets)
+    {
+        Map<RuneLimitGroup, Integer> runeCount = new EnumMap<>(RuneLimitGroup.class);
+        runeTrinkets.forEach(runeTrinket -> {
+            runeTrinket.getRunes().forEach(rune -> {
+                runeCount.merge(rune.getRuneLimitGroup(), 1, Integer::sum);
+            });
+        });
+
+        runeCount.forEach((runeLimitGroup, amount) -> {
+            if (runeLimitGroup.getLimit() < amount) throw new IllegalArgumentException("Rune limit exceeded for "+runeLimitGroup);
+        });
     }
 
     public Map<StatType, Double> calculateCharacterStats()

--- a/src/main/java/com/langleon/dsobuildsim/runes/RuneFactory.java
+++ b/src/main/java/com/langleon/dsobuildsim/runes/RuneFactory.java
@@ -1,6 +1,7 @@
 package com.langleon.dsobuildsim.runes;
 
 import com.langleon.dsobuildsim.runes.dto.RuneInstanceDTO;
+import com.langleon.dsobuildsim.runes.dto.RuneTrinketDTO;
 import com.langleon.dsobuildsim.runes.enums.RuneType;
 import com.langleon.dsobuildsim.runes.enums.RuneUpgradeType;
 
@@ -35,7 +36,7 @@ public class RuneFactory {
     public Rune createRune(RuneType runeType, int tier)
     {
         RuneDefinition runeDefinition = this.config.runes().get(runeType);
-        if (!runeDefinition.statsPerTier().containsKey(tier)) throw new IllegalArgumentException("Invalid pet tier: " + tier + "!");
+        if (!runeDefinition.statsPerTier().containsKey(tier)) throw new IllegalArgumentException("Invalid rune tier: " + tier + "!");
         return new Rune(runeType, runeDefinition.runeUpgradeType(), runeDefinition.runeLimitGroup(), tier, runeDefinition.statsPerTier().get(tier), runeDefinition.description());
     }
 
@@ -56,6 +57,19 @@ public class RuneFactory {
         if (dtos == null) return List.of();
         return dtos.stream()
                 .map(this::fromDTO)
+                .toList();
+    }
+
+    public RuneTrinket fromTrinketDTO(RuneTrinketDTO runeTrinketDTO)
+    {
+        return new RuneTrinket(fromDTOList(runeTrinketDTO.runes()));
+    }
+
+    public List<RuneTrinket> fromTrinketDTOList(List<RuneTrinketDTO> dtos)
+    {
+        if (dtos == null) return List.of();
+        return dtos.stream()
+                .map(this::fromTrinketDTO)
                 .toList();
     }
 }

--- a/src/main/java/com/langleon/dsobuildsim/runes/RuneTrinket.java
+++ b/src/main/java/com/langleon/dsobuildsim/runes/RuneTrinket.java
@@ -3,39 +3,20 @@ package com.langleon.dsobuildsim.runes;
 import com.langleon.dsobuildsim.common.StatType;
 
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 
 public class RuneTrinket {
 
-    private Rune[] runes;
+    private final List<Rune> runes;
 
-    public RuneTrinket() {
-        runes = new Rune[10];
-    }
-
-    public Rune[] getRunes() {
-        return runes;
-    }
-
-    public Rune getRune(int slot) {
-        return runes[slot];
-    }
-
-    public void addRune(Rune rune, int slot){
-        if (rune==null) throw new IllegalArgumentException("Rune is null!");
-        if (slot<0 || slot>10) throw new IllegalArgumentException("Index out of range!");
-        runes[slot] = rune;
-    }
-
-    public void removeRune(int slot){
-        if (slot<0 || slot>10) throw new IllegalArgumentException("Index out of range!");
-        runes[slot] = null;
-    }
-
-    public void updateRunes(Rune[] runes)
-    {
-        if (runes.length!=10) throw new IllegalArgumentException("Invalid array length!");
+    public RuneTrinket(List<Rune> runes) {
+        if (runes.size() > 10) throw new IllegalArgumentException("Rune Trinket can only hold up to 10 Runes.");
         this.runes = runes;
+    }
+
+    public List<Rune> getRunes() {
+        return runes;
     }
 
     public Map<StatType, Double> getTotalRelativeStats()
@@ -43,9 +24,9 @@ public class RuneTrinket {
         Map<StatType, Double> stats = new EnumMap<>(StatType.class);
         for(int i=0; i<10; i++)
         {
-            if (runes[i]!=null)
+            if (runes.get(i)!=null)
             {
-                for(Map.Entry<StatType, Double> entry : runes[i].getStats().entrySet())
+                for(Map.Entry<StatType, Double> entry : runes.get(i).getStats().entrySet())
                 {
                     stats.merge(entry.getKey(), entry.getValue(), Double::sum);
                 }

--- a/src/main/java/com/langleon/dsobuildsim/runes/dto/RuneTrinketDTO.java
+++ b/src/main/java/com/langleon/dsobuildsim/runes/dto/RuneTrinketDTO.java
@@ -1,0 +1,6 @@
+package com.langleon.dsobuildsim.runes.dto;
+
+import java.util.List;
+
+public record RuneTrinketDTO(List<RuneInstanceDTO> runes) {
+}

--- a/src/test/java/com/langleon/dsobuildsim/character/CharacterTest.java
+++ b/src/test/java/com/langleon/dsobuildsim/character/CharacterTest.java
@@ -1,6 +1,7 @@
 package com.langleon.dsobuildsim.character;
 
 import com.langleon.dsobuildsim.dragonstones.*;
+import com.langleon.dsobuildsim.runes.RuneTrinket;
 import com.langleon.dsobuildsim.wisdomskilltree.WisdomSkillTreeConfig;
 import com.langleon.dsobuildsim.wisdomskilltree.WisdomSkillTreeFactory;
 import com.langleon.dsobuildsim.wisdomskilltree.wisdomgroup.WisdomGroupConfig;
@@ -37,7 +38,6 @@ import com.langleon.dsobuildsim.jewels.JewelConfig;
 import com.langleon.dsobuildsim.jewels.JewelFactory;
 import com.langleon.dsobuildsim.pets.PetConfig;
 import com.langleon.dsobuildsim.pets.PetFactory;
-import com.langleon.dsobuildsim.runes.Rune;
 import com.langleon.dsobuildsim.runes.RuneConfig;
 import com.langleon.dsobuildsim.runes.RuneFactory;
 import com.langleon.dsobuildsim.sets.SetConfig;
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -173,21 +174,23 @@ public class CharacterTest {
 
     private Character createCharacter()
     {
+        List<RuneTrinket> runeTrinkets = new ArrayList<>();
+        runeTrinkets.add(new RuneTrinket(List.of(runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.DEVASTATION, 5), runeFactory.createRune(RuneType.DEVASTATION, 5), runeFactory.createRune(RuneType.DEVASTATION, 5), runeFactory.createRune(RuneType.DEVASTATION, 5), runeFactory.createRune(RuneType.DEVASTATION, 5))));
+        runeTrinkets.add(new RuneTrinket(List.of(runeFactory.createRune(RuneType.SPRING, 5), runeFactory.createRune(RuneType.SPRING, 5), runeFactory.createRune(RuneType.SPRING, 5), runeFactory.createRune(RuneType.SPRING, 5), runeFactory.createRune(RuneType.SPRING, 5), runeFactory.createRune(RuneType.SUMMER, 5), runeFactory.createRune(RuneType.SUMMER, 5), runeFactory.createRune(RuneType.SUMMER, 5), runeFactory.createRune(RuneType.SUMMER, 5), runeFactory.createRune(RuneType.SUMMER, 5))));
+        runeTrinkets.add(new RuneTrinket(List.of(runeFactory.createRune(RuneType.AUTUMN, 5), runeFactory.createRune(RuneType.AUTUMN, 5), runeFactory.createRune(RuneType.AUTUMN, 5), runeFactory.createRune(RuneType.AUTUMN, 5), runeFactory.createRune(RuneType.AUTUMN, 5), runeFactory.createRune(RuneType.WINTER, 5), runeFactory.createRune(RuneType.WINTER, 5), runeFactory.createRune(RuneType.WINTER, 5), runeFactory.createRune(RuneType.WINTER, 5), runeFactory.createRune(RuneType.WINTER, 5))));
+        runeTrinkets.add(new RuneTrinket(List.of(runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5))));
+        runeTrinkets.add(new RuneTrinket(List.of(runeFactory.createRune(RuneType.PERSISTENCE, 5), runeFactory.createRune(RuneType.PERSISTENCE, 5), runeFactory.createRune(RuneType.PERSISTENCE, 5), runeFactory.createRune(RuneType.PERSISTENCE, 5), runeFactory.createRune(RuneType.PERSISTENCE, 5), runeFactory.createRune(RuneType.ACCELERATION, 5), runeFactory.createRune(RuneType.ACCELERATION, 5), runeFactory.createRune(RuneType.ACCELERATION, 5), runeFactory.createRune(RuneType.ACCELERATION, 5), runeFactory.createRune(RuneType.ACCELERATION, 5))));
+        runeTrinkets.add(new RuneTrinket(List.of(runeFactory.createRune(RuneType.HOLY_STAR_SHARD, 7), runeFactory.createRune(RuneType.RISING_VIGOR, 6), runeFactory.createRune(RuneType.FORTITUDE, 5), runeFactory.createRune(RuneType.FORTITUDE, 5), runeFactory.createRune(RuneType.FORTITUDE, 5), runeFactory.createRune(RuneType.ANDERMANT_FEVER, 5), runeFactory.createRune(RuneType.REALM_CHANGER, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5))));
+
+
         DragonCrestTrinket dragonCrest = new DragonCrestTrinket(List.of(dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 5), dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 5), dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3), dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3), dragonStoneFactory.createDragonStone(DragonStoneType.POWERSTONE, 3)));
 
         Character character = new Character(CharacterClass.SPELLWEAVER, setFactory, wisdomSkillTreeFactory,
-                dragonCrest);
+                runeTrinkets, dragonCrest);
 
         character.setExperienceBonusPathLevel(5);
         character.setElementalMasteryType(MasteryType.ICE);
         character.setElementalMasteryLevel(3);
-
-        character.updateRuneTrinket(0, new Rune[]{runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.DEVASTATION, 5), runeFactory.createRune(RuneType.DEVASTATION, 5), runeFactory.createRune(RuneType.DEVASTATION, 5), runeFactory.createRune(RuneType.DEVASTATION, 5), runeFactory.createRune(RuneType.DEVASTATION, 5),});
-        character.updateRuneTrinket(1, new Rune[]{runeFactory.createRune(RuneType.SPRING, 5), runeFactory.createRune(RuneType.SPRING, 5), runeFactory.createRune(RuneType.SPRING, 5), runeFactory.createRune(RuneType.SPRING, 5), runeFactory.createRune(RuneType.SPRING, 5), runeFactory.createRune(RuneType.SUMMER, 5), runeFactory.createRune(RuneType.SUMMER, 5), runeFactory.createRune(RuneType.SUMMER, 5), runeFactory.createRune(RuneType.SUMMER, 5), runeFactory.createRune(RuneType.SUMMER, 5),});
-        character.updateRuneTrinket(2, new Rune[]{runeFactory.createRune(RuneType.AUTUMN, 5), runeFactory.createRune(RuneType.AUTUMN, 5), runeFactory.createRune(RuneType.AUTUMN, 5), runeFactory.createRune(RuneType.AUTUMN, 5), runeFactory.createRune(RuneType.AUTUMN, 5), runeFactory.createRune(RuneType.WINTER, 5), runeFactory.createRune(RuneType.WINTER, 5), runeFactory.createRune(RuneType.WINTER, 5), runeFactory.createRune(RuneType.WINTER, 5), runeFactory.createRune(RuneType.WINTER, 5),});
-        character.updateRuneTrinket(3, new Rune[]{runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5),});
-        character.updateRuneTrinket(4, new Rune[]{runeFactory.createRune(RuneType.PERSISTENCE, 5), runeFactory.createRune(RuneType.PERSISTENCE, 5), runeFactory.createRune(RuneType.PERSISTENCE, 5), runeFactory.createRune(RuneType.PERSISTENCE, 5), runeFactory.createRune(RuneType.PERSISTENCE, 5), runeFactory.createRune(RuneType.ACCELERATION, 5), runeFactory.createRune(RuneType.ACCELERATION, 5), runeFactory.createRune(RuneType.ACCELERATION, 5), runeFactory.createRune(RuneType.ACCELERATION, 5), runeFactory.createRune(RuneType.ACCELERATION, 5),});
-        character.updateRuneTrinket(5, new Rune[]{runeFactory.createRune(RuneType.HOLY_STAR_SHARD, 7), runeFactory.createRune(RuneType.RISING_VIGOR, 6), runeFactory.createRune(RuneType.FORTITUDE, 5), runeFactory.createRune(RuneType.FORTITUDE, 5), runeFactory.createRune(RuneType.FORTITUDE, 5), runeFactory.createRune(RuneType.ANDERMANT_FEVER, 5), runeFactory.createRune(RuneType.REALM_CHANGER, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5),});
 
         character.updateJewelTrinket(0, new Jewel[]{jewelFactory.createJewel(JewelType.ETERNAL_SCORN, CharacterClass.SPELLWEAVER, 7), jewelFactory.createJewel(JewelType.GLORY, CharacterClass.SPELLWEAVER, 7), jewelFactory.createJewel(JewelType.RAGE, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.AMPLIFIED_HEALING, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FROZEN_HEART, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.GEM_FORTUNE, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.ETERNAL_WRATH, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.INGREDIENT_HUNTER, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.INGREDIENT_HUNTER, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.INGREDIENT_HUNTER, CharacterClass.SPELLWEAVER, 5),});
         character.updateJewelTrinket(1, new Jewel[]{jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.VIGOR, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.AMBIDEXTROUS_VIGOR, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.VITALITY, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.ENCOURAGEMENT, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.CONTRIBUTION, CharacterClass.SPELLWEAVER, 5),});

--- a/src/test/java/com/langleon/dsobuildsim/character/EquipmentLimitTest.java
+++ b/src/test/java/com/langleon/dsobuildsim/character/EquipmentLimitTest.java
@@ -1,5 +1,6 @@
 package com.langleon.dsobuildsim.character;
 
+import com.langleon.dsobuildsim.runes.RuneTrinket;
 import com.langleon.dsobuildsim.wisdomskilltree.WisdomSkillTreeConfig;
 import com.langleon.dsobuildsim.wisdomskilltree.WisdomSkillTreeFactory;
 import com.langleon.dsobuildsim.wisdomskilltree.wisdomgroup.WisdomGroupConfig;
@@ -23,10 +24,8 @@ import com.langleon.dsobuildsim.jewels.Jewel;
 import com.langleon.dsobuildsim.jewels.JewelConfig;
 import com.langleon.dsobuildsim.jewels.JewelFactory;
 import com.langleon.dsobuildsim.jewels.JewelType;
-import com.langleon.dsobuildsim.runes.Rune;
 import com.langleon.dsobuildsim.runes.RuneConfig;
 import com.langleon.dsobuildsim.runes.RuneFactory;
-import com.langleon.dsobuildsim.runes.enums.RuneLimitGroup;
 import com.langleon.dsobuildsim.runes.enums.RuneType;
 import com.langleon.dsobuildsim.sets.SetConfig;
 import com.langleon.dsobuildsim.sets.SetFactory;
@@ -37,6 +36,8 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -113,7 +114,7 @@ public class EquipmentLimitTest {
     // Gems
     @Test
     void updateItemGems_succeedsIfWithinGemLimit() throws NoSuchFieldException, IllegalAccessException {
-        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, null);
+        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, List.of(), null);
         character.equipItem(ItemSlot.AMULET, itemFactory.createItem(SetItemType.WINTER_AMULET, CharacterClass.SPELLWEAVER, Map.of(StatType.DAMAGE, 0.0, StatType.MOVEMENT_SPEED, 0.0, StatType.HEALTH_POINTS, 0.0), 145));
         character.updateItemGems(ItemSlot.AMULET, new Gem[]{gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17)});
         character.equipItem(ItemSlot.CLOAK, itemFactory.createItem(SetItemType.DRAGAN_CLOAK, CharacterClass.SPELLWEAVER, Map.of(StatType.DAMAGE, 0.0, StatType.ATTACK_SPEED, 0.0, StatType.HEALTH_POINTS, 0.0), 145));
@@ -134,7 +135,7 @@ public class EquipmentLimitTest {
     @Test
     void equipItem_updateItemGems_throwsIfGemLimitExceeded()
     {
-        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, null);
+        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, List.of(), null);
         Item amulet = itemFactory.createItem(SetItemType.WINTER_AMULET, CharacterClass.SPELLWEAVER, Map.of(StatType.DAMAGE, 0.0, StatType.MOVEMENT_SPEED, 0.0, StatType.HEALTH_POINTS, 0.0), 145);
         amulet.setGems(new Gem[]{gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17)});
         character.equipItem(ItemSlot.AMULET, amulet);
@@ -159,7 +160,7 @@ public class EquipmentLimitTest {
     @Test
     void updateItemGems_throwsIfGemLimitExceeded()
     {
-        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, null);
+        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, List.of(), null);
         character.equipItem(ItemSlot.AMULET, itemFactory.createItem(SetItemType.WINTER_AMULET, CharacterClass.SPELLWEAVER, Map.of(StatType.DAMAGE, 0.0, StatType.MOVEMENT_SPEED, 0.0, StatType.HEALTH_POINTS, 0.0), 145));
         character.updateItemGems(ItemSlot.AMULET, new Gem[]{gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17), gemFactory.createGem(GemType.RUBY, 17)});
         character.equipItem(ItemSlot.CLOAK, itemFactory.createItem(SetItemType.DRAGAN_CLOAK, CharacterClass.SPELLWEAVER, Map.of(StatType.DAMAGE, 0.0, StatType.ATTACK_SPEED, 0.0, StatType.HEALTH_POINTS, 0.0), 145));
@@ -177,37 +178,36 @@ public class EquipmentLimitTest {
 
     // Runes
     @Test
-    void updateRuneTrinket_succeedsIfWithinRuneLimit() throws IllegalAccessException, NoSuchFieldException {
-        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, null);
-        character.updateRuneTrinket(0, new Rune[]{runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5)});
-        character.updateRuneTrinket(1, new Rune[]{runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5)});
-        character.updateRuneTrinket(2, new Rune[]{runeFactory.createRune(RuneType.MATERI_BLESSING, 5), runeFactory.createRune(RuneType.MATERI_BLESSING, 5), runeFactory.createRune(RuneType.MATERI_BLESSING, 5), runeFactory.createRune(RuneType.MATERI_BLESSING, 5), runeFactory.createRune(RuneType.MATERI_BLESSING, 5), runeFactory.createRune(RuneType.WISDOM_SEEKER, 5), runeFactory.createRune(RuneType.WISDOM_SEEKER, 5), runeFactory.createRune(RuneType.WISDOM_SEEKER, 5), runeFactory.createRune(RuneType.WISDOM_SEEKER, 5), runeFactory.createRune(RuneType.WISDOM_SEEKER, 5)});
-
-        Field runeLimitsField = Character.class.getDeclaredField("runeLimits");
-        runeLimitsField.setAccessible(true);
-        Map<RuneLimitGroup, Integer> runeLimits = (Map<RuneLimitGroup, Integer>) runeLimitsField.get(character);
-
-        Assertions.assertEquals(5, runeLimits.get(RuneLimitGroup.VIGOR));
-        Assertions.assertEquals(5, runeLimits.get(RuneLimitGroup.VITALITY));
-        Assertions.assertEquals(5, runeLimits.get(RuneLimitGroup.CELERITY));
-        Assertions.assertEquals(5, runeLimits.get(RuneLimitGroup.RESILIENCE));
-        Assertions.assertEquals(5, runeLimits.get(RuneLimitGroup.MATERI_BLESSING));
-        Assertions.assertEquals(5, runeLimits.get(RuneLimitGroup.WISDOM_SEEKER));
+    void updateRuneTrinket_succeedsIfWithinRuneLimit() {
+        List<RuneTrinket> runeTrinkets = new ArrayList<>();
+        runeTrinkets.add(new RuneTrinket(List.of(runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5))));
+        runeTrinkets.add(new RuneTrinket(List.of(runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.CELERITY, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5))));
+        runeTrinkets.add(new RuneTrinket(List.of(runeFactory.createRune(RuneType.MATERI_BLESSING, 5), runeFactory.createRune(RuneType.MATERI_BLESSING, 5), runeFactory.createRune(RuneType.MATERI_BLESSING, 5), runeFactory.createRune(RuneType.MATERI_BLESSING, 5), runeFactory.createRune(RuneType.MATERI_BLESSING, 5), runeFactory.createRune(RuneType.WISDOM_SEEKER, 5), runeFactory.createRune(RuneType.WISDOM_SEEKER, 5), runeFactory.createRune(RuneType.WISDOM_SEEKER, 5), runeFactory.createRune(RuneType.WISDOM_SEEKER, 5), runeFactory.createRune(RuneType.WISDOM_SEEKER, 5))));
+        Assertions.assertDoesNotThrow(() -> new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, runeTrinkets, null));
     }
 
     @Test
-    void updateRuneTrinket_throwsIfRuneLimitExceeded()
+    void updateRuneTrinket_throwsIfRuneLimitExceededOnOneTrinket()
     {
-        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, null);
-        Assertions.assertThrows(IllegalArgumentException.class, () -> character.updateRuneTrinket(0, new Rune[]{runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5)}));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> character.updateRuneTrinket(0, new Rune[]{runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.FIRE_RESILIENCE, 5), runeFactory.createRune(RuneType.FIRE_RESILIENCE, 5), runeFactory.createRune(RuneType.FIRE_RESILIENCE, 5), runeFactory.createRune(RuneType.FIRE_RESILIENCE, 5), runeFactory.createRune(RuneType.ICE_RESILIENCE, 5), runeFactory.createRune(RuneType.ICE_RESILIENCE, 5)}));
-        Assertions.assertThrows(IllegalArgumentException.class, () -> character.updateRuneTrinket(0, new Rune[]{runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.RISING_VIGOR, 5), runeFactory.createRune(RuneType.RISING_POWER, 5)}));
+        List<RuneTrinket> runeTrinkets = new ArrayList<>();
+        runeTrinkets.add(new RuneTrinket(List.of(runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.RESILIENCE, 5), runeFactory.createRune(RuneType.FIRE_RESILIENCE, 5), runeFactory.createRune(RuneType.FIRE_RESILIENCE, 5), runeFactory.createRune(RuneType.FIRE_RESILIENCE, 5), runeFactory.createRune(RuneType.FIRE_RESILIENCE, 5), runeFactory.createRune(RuneType.ICE_RESILIENCE, 5), runeFactory.createRune(RuneType.ICE_RESILIENCE, 5))));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, runeTrinkets, null));
+    }
+
+
+    @Test
+    void updateRuneTrinket_throwsIfRuneLimitExceededOnMultipleTrinkets()
+    {
+        List<RuneTrinket> runeTrinkets = new ArrayList<>();
+        runeTrinkets.add(new RuneTrinket(List.of(runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5))));
+        runeTrinkets.add(new RuneTrinket(List.of(runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VIGOR, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.VITALITY, 5), runeFactory.createRune(RuneType.RISING_VIGOR, 6), runeFactory.createRune(RuneType.RISING_POWER, 6))));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, runeTrinkets, null));
     }
 
     // Jewels
     @Test
     void updateJewelTrinket_succeedsIfWithinJewelLimit() throws IllegalAccessException, NoSuchFieldException {
-        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, null);
+        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, List.of(), null);
         character.updateJewelTrinket(0, new Jewel[]{jewelFactory.createJewel(JewelType.FOCUS,  CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.RAGE, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.SCORCHING_RAY, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.ETERNAL_SCORN, CharacterClass.SPELLWEAVER, 7), jewelFactory.createJewel(JewelType.ETERNAL_WRATH, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.INGREDIENT_HUNTER, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.AMBIDEXTROUS_VIGOR, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.VITALITY, CharacterClass.SPELLWEAVER, 5)});
 
         Field jewelLimitsField = Character.class.getDeclaredField("jewelLimits");
@@ -227,7 +227,7 @@ public class EquipmentLimitTest {
     @Test
     void updateJewelTrinket_throwsIfJewelLimitExceeded()
     {
-        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, null);
+        Character character = new Character(CharacterClass.SPELLWEAVER, this.setFactory, wisdomSkillTreeFactory, List.of(), null);
         character.updateJewelTrinket(0, new Jewel[]{jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.RAGE, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.SCORCHING_RAY, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.ETERNAL_SCORN, CharacterClass.SPELLWEAVER, 7), jewelFactory.createJewel(JewelType.ETERNAL_WRATH, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.GEM_FORTUNE, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.AMBIDEXTROUS_VIGOR, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.VITALITY, CharacterClass.SPELLWEAVER, 5)});
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> character.updateJewelTrinket(1, new Jewel[]{jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.FOCUS, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.BLACK_KNIGHT_ORDER, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.INGREDIENT_HUNTER, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.INGREDIENT_HUNTER, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.INGREDIENT_HUNTER, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.VIGOR, CharacterClass.SPELLWEAVER, 5), jewelFactory.createJewel(JewelType.GLORY, CharacterClass.SPELLWEAVER, 5)}));

--- a/src/test/java/com/langleon/dsobuildsim/runes/RuneFactoryTest.java
+++ b/src/test/java/com/langleon/dsobuildsim/runes/RuneFactoryTest.java
@@ -1,7 +1,7 @@
 package com.langleon.dsobuildsim.runes;
 
-import com.langleon.dsobuildsim.runes.dto.RuneDefinitionDTO;
 import com.langleon.dsobuildsim.runes.dto.RuneInstanceDTO;
+import com.langleon.dsobuildsim.runes.dto.RuneTrinketDTO;
 import tools.jackson.databind.ObjectMapper;
 import com.langleon.dsobuildsim.common.StatType;
 import com.langleon.dsobuildsim.runes.enums.RuneLimitGroup;
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 class RuneFactoryTest {
 
@@ -22,7 +23,7 @@ class RuneFactoryTest {
 
     @BeforeEach
     void setup() throws IOException {
-        try (var reader = new InputStreamReader(getClass().getResourceAsStream("/gamedata/runes.json")))
+        try (var reader = new InputStreamReader(Objects.requireNonNull(getClass().getResourceAsStream("/gamedata/runes.json"))))
         {
             ObjectMapper objectMapper = new ObjectMapper();
             RuneConfig runeConfig = objectMapper.readValue(reader, RuneConfig.class);
@@ -124,5 +125,55 @@ class RuneFactoryTest {
         Assertions.assertEquals(RuneLimitGroup.VITALITY, runes.get(1).getRuneLimitGroup());
         Assertions.assertEquals(4, runes.get(1).getTier());
         Assertions.assertEquals(Map.of(StatType.HEALTH_POINTS, 0.052), runes.get(1).getStats());
+    }
+
+    @Test
+    void shouldResolveRuneTrinketFromRuneTrinketDTO()
+    {
+        RuneInstanceDTO runeDTO1 = new RuneInstanceDTO(RuneType.VIGOR, 4);
+        RuneInstanceDTO runeDTO2 = new RuneInstanceDTO(RuneType.VITALITY, 4);
+        RuneTrinketDTO runeTrinketDTO = new RuneTrinketDTO(List.of(runeDTO1, runeDTO2));
+
+        RuneTrinket runeTrinket = runeFactory.fromTrinketDTO(runeTrinketDTO);
+
+        Assertions.assertEquals(RuneType.VIGOR, runeTrinket.getRunes().getFirst().getRuneType());
+        Assertions.assertEquals(RuneLimitGroup.VIGOR, runeTrinket.getRunes().getFirst().getRuneLimitGroup());
+        Assertions.assertEquals(4, runeTrinket.getRunes().getFirst().getTier());
+        Assertions.assertEquals(Map.of(StatType.DAMAGE, 0.052), runeTrinket.getRunes().getFirst().getStats());
+        Assertions.assertEquals(RuneType.VITALITY, runeTrinket.getRunes().get(1).getRuneType());
+        Assertions.assertEquals(RuneLimitGroup.VITALITY, runeTrinket.getRunes().get(1).getRuneLimitGroup());
+        Assertions.assertEquals(4, runeTrinket.getRunes().get(1).getTier());
+        Assertions.assertEquals(Map.of(StatType.HEALTH_POINTS, 0.052), runeTrinket.getRunes().get(1).getStats());
+    }
+
+    @Test
+    void shouldResolveRuneTrinketFromRuneTrinketDTOs()
+    {
+        RuneInstanceDTO runeDTO1 = new RuneInstanceDTO(RuneType.VIGOR, 4);
+        RuneInstanceDTO runeDTO2 = new RuneInstanceDTO(RuneType.VITALITY, 4);
+        RuneTrinketDTO runeTrinketDTO1 = new RuneTrinketDTO(List.of(runeDTO1, runeDTO2));
+        RuneInstanceDTO runeDTO3 = new RuneInstanceDTO(RuneType.RESILIENCE, 4);
+        RuneInstanceDTO runeDTO4 = new RuneInstanceDTO(RuneType.CELERITY, 4);
+        RuneTrinketDTO runeTrinketDTO2 = new RuneTrinketDTO(List.of(runeDTO3, runeDTO4));
+
+        List<RuneTrinket> runeTrinkets = runeFactory.fromTrinketDTOList(List.of(runeTrinketDTO1, runeTrinketDTO2));
+
+        Assertions.assertEquals(RuneType.VIGOR, runeTrinkets.getFirst().getRunes().getFirst().getRuneType());
+        Assertions.assertEquals(RuneLimitGroup.VIGOR, runeTrinkets.getFirst().getRunes().getFirst().getRuneLimitGroup());
+        Assertions.assertEquals(4, runeTrinkets.getFirst().getRunes().getFirst().getTier());
+        Assertions.assertEquals(Map.of(StatType.DAMAGE, 0.052), runeTrinkets.getFirst().getRunes().getFirst().getStats());
+        Assertions.assertEquals(RuneType.VITALITY, runeTrinkets.getFirst().getRunes().get(1).getRuneType());
+        Assertions.assertEquals(RuneLimitGroup.VITALITY, runeTrinkets.getFirst().getRunes().get(1).getRuneLimitGroup());
+        Assertions.assertEquals(4, runeTrinkets.getFirst().getRunes().get(1).getTier());
+        Assertions.assertEquals(Map.of(StatType.HEALTH_POINTS, 0.052), runeTrinkets.getFirst().getRunes().get(1).getStats());
+
+        Assertions.assertEquals(RuneType.RESILIENCE, runeTrinkets.get(1).getRunes().getFirst().getRuneType());
+        Assertions.assertEquals(RuneLimitGroup.RESILIENCE, runeTrinkets.get(1).getRunes().getFirst().getRuneLimitGroup());
+        Assertions.assertEquals(4, runeTrinkets.get(1).getRunes().getFirst().getTier());
+        Assertions.assertEquals(Map.of(StatType.RESISTANCE_VALUE, 0.052), runeTrinkets.get(1).getRunes().getFirst().getStats());
+        Assertions.assertEquals(RuneType.CELERITY, runeTrinkets.get(1).getRunes().get(1).getRuneType());
+        Assertions.assertEquals(RuneLimitGroup.CELERITY, runeTrinkets.get(1).getRunes().get(1).getRuneLimitGroup());
+        Assertions.assertEquals(4, runeTrinkets.get(1).getRunes().get(1).getTier());
+        Assertions.assertEquals(Map.of(StatType.ATTACK_SPEED, 0.052), runeTrinkets.get(1).getRunes().get(1).getStats());
     }
 }

--- a/src/test/java/com/langleon/dsobuildsim/runes/RuneTrinketTest.java
+++ b/src/test/java/com/langleon/dsobuildsim/runes/RuneTrinketTest.java
@@ -9,75 +9,56 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class RuneTrinketTest {
 
-    private RuneFactory dragonStoneFactory;
+    private RuneFactory runeFactory;
 
     @BeforeEach
     void setup() throws IOException
     {
-        try (var reader = new InputStreamReader(getClass().getResourceAsStream("/gamedata/runes.json")))
+        try (var reader = new InputStreamReader(Objects.requireNonNull(getClass().getResourceAsStream("/gamedata/runes.json"))))
         {
             ObjectMapper objectMapper = new ObjectMapper();
             RuneConfig dragonStoneConfig = objectMapper.readValue(reader, RuneConfig.class);
-            dragonStoneFactory = new RuneFactory(dragonStoneConfig);
+            runeFactory = new RuneFactory(dragonStoneConfig);
         }
     }
 
     @Test
-    void testDragonCrestCreation()
+    void testRuneTrinketCreation()
     {
-        RuneTrinket runeTrinket = new RuneTrinket();
-        Assertions.assertNotNull(runeTrinket);
-    }
-
-    @Test
-    void testAddRunes()
-    {
-        RuneTrinket runeTrinket = new RuneTrinket();
-        runeTrinket.addRune(dragonStoneFactory.createRune(RuneType.VIGOR, 3),2);
-        runeTrinket.addRune(dragonStoneFactory.createRune(RuneType.WINTER,5),9);
-        runeTrinket.addRune(dragonStoneFactory.createRune(RuneType.VITALITY, 2),3);
-        Rune[] runes = runeTrinket.getRunes();
+        List<Rune> runesActual = new ArrayList<>();
+        runesActual.add(runeFactory.createRune(RuneType.VIGOR, 3));
+        runesActual.add(runeFactory.createRune(RuneType.WINTER,5));
+        runesActual.add(runeFactory.createRune(RuneType.VITALITY, 2));
+        RuneTrinket runeTrinket = new RuneTrinket(runesActual);
+        List<Rune> runes = runeTrinket.getRunes();
         Assertions.assertNotNull(runes);
-        Assertions.assertEquals(dragonStoneFactory.createRune(RuneType.VIGOR, 3), runes[2]);
-        Assertions.assertEquals(dragonStoneFactory.createRune(RuneType.WINTER,5), runes[9]);
-        Assertions.assertEquals(dragonStoneFactory.createRune(RuneType.VITALITY, 2), runes[3]);
-        Assertions.assertNull(runes[1]);
-        Assertions.assertEquals(dragonStoneFactory.createRune(RuneType.VIGOR, 3), runeTrinket.getRune(2));
-        Assertions.assertEquals(dragonStoneFactory.createRune(RuneType.WINTER, 5), runeTrinket.getRune(9));
-        Assertions.assertEquals(dragonStoneFactory.createRune(RuneType.VITALITY, 2), runeTrinket.getRune(3));
-        Assertions.assertNull(runeTrinket.getRune(1));
-    }
-
-    @Test
-    void testRemoveRunes()
-    {
-        RuneTrinket runeTrinket = new RuneTrinket();
-        runeTrinket.addRune(dragonStoneFactory.createRune(RuneType.VIGOR, 3),2);
-        runeTrinket.addRune(dragonStoneFactory.createRune(RuneType.WINTER,5),9);
-        runeTrinket.addRune(dragonStoneFactory.createRune(RuneType.VITALITY, 2),3);
-        Assertions.assertEquals(dragonStoneFactory.createRune(RuneType.VITALITY, 2), runeTrinket.getRunes()[3]);
-        runeTrinket.removeRune(3);
-        Assertions.assertNull(runeTrinket.getRune(3));
+        Assertions.assertEquals(runeFactory.createRune(RuneType.VIGOR, 3), runes.getFirst());
+        Assertions.assertEquals(runeFactory.createRune(RuneType.WINTER,5), runes.get(1));
+        Assertions.assertEquals(runeFactory.createRune(RuneType.VITALITY, 2), runes.get(2));
     }
 
     @Test
     void testGetTotalStats()
     {
-        RuneTrinket runeTrinket = new RuneTrinket();
-        runeTrinket.addRune(dragonStoneFactory.createRune(RuneType.VIGOR, 5),0);
-        runeTrinket.addRune(dragonStoneFactory.createRune(RuneType.VIGOR, 5),1);
-        runeTrinket.addRune(dragonStoneFactory.createRune(RuneType.DEVASTATION, 1),1);
-        runeTrinket.addRune(dragonStoneFactory.createRune(RuneType.CELERITY, 2),3);
-        runeTrinket.addRune(dragonStoneFactory.createRune(RuneType.CELERITY, 2),4);
-        runeTrinket.addRune(dragonStoneFactory.createRune(RuneType.VITALITY, 5),5);
-        runeTrinket.addRune(dragonStoneFactory.createRune(RuneType.WINTER, 5),6);
-        runeTrinket.addRune(dragonStoneFactory.createRune(RuneType.WINTER, 5),7);
-        runeTrinket.addRune(dragonStoneFactory.createRune(RuneType.WINTER, 5),8);
-        runeTrinket.addRune(dragonStoneFactory.createRune(RuneType.ACCELERATION, 2),9);
+        List<Rune> runes = new ArrayList<>();
+        runes.add(runeFactory.createRune(RuneType.VIGOR, 5));
+        runes.add(runeFactory.createRune(RuneType.VIGOR, 5));
+        runes.add(runeFactory.createRune(RuneType.DEVASTATION, 1));
+        runes.add(runeFactory.createRune(RuneType.CELERITY, 2));
+        runes.add(runeFactory.createRune(RuneType.CELERITY, 2));
+        runes.add(runeFactory.createRune(RuneType.VITALITY, 5));
+        runes.add(runeFactory.createRune(RuneType.WINTER, 5));
+        runes.add(runeFactory.createRune(RuneType.WINTER, 5));
+        runes.add(runeFactory.createRune(RuneType.WINTER, 5));
+        runes.add(runeFactory.createRune(RuneType.ACCELERATION, 2));
+        RuneTrinket runeTrinket = new RuneTrinket(runes);
         Map<StatType, Double> stats = runeTrinket.getTotalRelativeStats();
         Assertions.assertEquals(6, stats.size());
         Assertions.assertTrue(stats.containsKey(StatType.HEALTH_POINTS));
@@ -90,7 +71,7 @@ public class RuneTrinketTest {
         Assertions.assertEquals(0.208, stats.get(StatType.CRIT_VALUE), 1e-9);
         Assertions.assertEquals(0.195, stats.get(StatType.ICE_RESISTANCE), 1e-9);
         Assertions.assertEquals(0.026, stats.get(StatType.MOVEMENT_SPEED), 1e-9);
-        Assertions.assertEquals(0.065, stats.get(StatType.DAMAGE), 1e-9);
+        Assertions.assertEquals(0.13, stats.get(StatType.DAMAGE), 1e-9);
         Assertions.assertEquals(0.052, stats.get(StatType.ATTACK_SPEED), 1e-9);
     }
 }


### PR DESCRIPTION
Introduce RuneTrinketDTO to model rune slots as a structured container instead of using nested lists.
Replace array-based rune storage in trinkets with List to improve consistency and simplify DTO mapping.
Fixed-size constraints (7 trinkets, 10 runes each) are now enforced in factory validation.